### PR TITLE
Implement focused examples

### DIFF
--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/CoreExtensions.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/CoreExtensions.kt
@@ -1,13 +1,19 @@
-package io.polymorphicpanda.kspec.extension
+package io.polymorphicpanda.kspec
 
 import io.polymorphicpanda.kspec.config.KSpecConfig
 import io.polymorphicpanda.kspec.context.ExampleGroupContext
+import io.polymorphicpanda.kspec.extension.Extension
+import io.polymorphicpanda.kspec.filter.Filter
+import io.polymorphicpanda.kspec.filter.Focused
+import io.polymorphicpanda.kspec.pending.Pending
 
 /**
  * @author Ranie Jade Ramiso
  */
 internal object CoreExtensions: Extension {
     val extensions = listOf(
+            Focused,
+            Filter,
             Pending
     )
 

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/Terms.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/Terms.kt
@@ -1,7 +1,8 @@
 package io.polymorphicpanda.kspec
 
-import io.polymorphicpanda.kspec.tag.pending
 import io.polymorphicpanda.kspec.tag.Tag
+import io.polymorphicpanda.kspec.tag.focus
+import io.polymorphicpanda.kspec.tag.pending
 import kotlin.reflect.KClass
 
 fun Spec.describe(description: String, action: () -> Unit) {
@@ -22,6 +23,10 @@ fun <T: Any> Spec.context(subject: KClass<T>, description: String = "%s", action
 
 fun Spec.it(description: String, vararg tags: Tag, action: () -> Unit) {
     example("it: $description", setOf(*tags), action)
+}
+
+fun Spec.fit(description: String, vararg tags: Tag, action: () -> Unit) {
+    example("it: $description", setOf(focus(), *tags), action)
 }
 
 fun Spec.xit(description: String, reason: String? = null, block: (() -> Unit)? = null) {

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/config/FilterConfig.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/config/FilterConfig.kt
@@ -1,0 +1,31 @@
+package io.polymorphicpanda.kspec.config
+
+import io.polymorphicpanda.kspec.tag.Tag
+import java.util.*
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+class FilterConfig {
+    private val _includes = HashSet<Tag>()
+    val includes: Set<Tag> = _includes
+
+    private val _excludes = HashSet<Tag>()
+    val excludes: Set<Tag> = _excludes
+
+    private val _match = HashSet<Tag>()
+    val match: Set<Tag> = _match
+
+
+    fun include(vararg tags: Tag) {
+        _includes.addAll(tags)
+    }
+
+    fun exclude(vararg tags: Tag) {
+        _excludes.addAll(tags)
+    }
+
+    fun matching(vararg tags: Tag) {
+        _match.addAll(tags)
+    }
+}

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/config/FilterConfig.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/config/FilterConfig.kt
@@ -8,13 +8,13 @@ import java.util.*
  */
 class FilterConfig {
     private val _includes = HashSet<Tag>()
-    val includes: Set<Tag> = _includes
+    internal val includes: Set<Tag> = _includes
 
     private val _excludes = HashSet<Tag>()
-    val excludes: Set<Tag> = _excludes
+    internal val excludes: Set<Tag> = _excludes
 
     private val _match = HashSet<Tag>()
-    val match: Set<Tag> = _match
+    internal val match: Set<Tag> = _match
 
 
     fun include(vararg tags: Tag) {

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/config/KSpecConfig.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/config/KSpecConfig.kt
@@ -12,13 +12,13 @@ import java.util.*
  */
 class KSpecConfig {
     private val _before = LinkedList<SimpleHook>()
-    val before: List<SimpleHook> = _before
+    internal val before: List<SimpleHook> = _before
 
     private val _after = LinkedList<SimpleHook>()
-    val after: List<SimpleHook> = _after
+    internal val after: List<SimpleHook> = _after
 
     private val _around = LinkedList<AroundHook>()
-    val around: List<AroundHook> = _around
+    internal val around: List<AroundHook> = _around
 
     val filter = FilterConfig()
 

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/config/KSpecConfig.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/config/KSpecConfig.kt
@@ -20,6 +20,8 @@ class KSpecConfig {
     private val _around = LinkedList<AroundHook>()
     val around: List<AroundHook> = _around
 
+    val filter = FilterConfig()
+
     fun before(vararg tags: Tag, block: (ExampleContext) -> Unit) {
         _before.add(SimpleHook(block, setOf(*tags)))
     }
@@ -30,15 +32,5 @@ class KSpecConfig {
 
     fun around(vararg tags: Tag, block: (ExampleContext, Chain) -> Unit) {
         _around.add(AroundHook(block, setOf(*tags)))
-    }
-
-    fun clone(): KSpecConfig {
-        val clone = KSpecConfig()
-
-        clone._before.addAll(this.before)
-        clone._after.addAll(this.after)
-        clone._around.addAll(this.around)
-
-        return clone
     }
 }

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/context/Context.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/context/Context.kt
@@ -75,7 +75,9 @@ class ExampleContext(description: String, val parent: ExampleGroupContext,
         action!!()
     }
 
-    fun contains(tag: String): Boolean = tags.any { it.name == tag }
+    fun contains(vararg tags: Tag): Boolean = this.tags.any { tags.contains(it) }
+
+    fun contains(tags: Collection<Tag>): Boolean = this.tags.any { tags.contains(it) }
 
     operator fun get(tag: String): Tag? = tags.firstOrNull { it.name == tag }
 }

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/filter/Filter.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/filter/Filter.kt
@@ -1,0 +1,86 @@
+package io.polymorphicpanda.kspec.filter
+
+import io.polymorphicpanda.kspec.config.KSpecConfig
+import io.polymorphicpanda.kspec.context.ContextVisitor
+import io.polymorphicpanda.kspec.context.ExampleContext
+import io.polymorphicpanda.kspec.context.ExampleGroupContext
+import io.polymorphicpanda.kspec.extension.Extension
+import io.polymorphicpanda.kspec.tag.Tag
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+object Filter: Extension {
+
+    override fun configure(config: KSpecConfig, root: ExampleGroupContext) {
+
+        val match = config.filter.match
+
+        if (match.isNotEmpty() && hasMatch(match, root)) {
+            config.around { example, chain ->
+                if (example.contains(match)) {
+                    chain.next(example)
+                } else {
+                    chain.stop("Not matching include filter")
+                }
+            }
+        }
+
+        val includes = config.filter.includes
+
+        if (includes.isNotEmpty()) {
+            config.around { example, chain ->
+                if (example.contains(includes)) {
+                    chain.next(example)
+                } else {
+                    chain.stop("Not matching include filter")
+                }
+            }
+        }
+
+        val excludes = config.filter.excludes
+
+        if (excludes.isNotEmpty()) {
+            config.around { example, chain ->
+                if (!example.contains(excludes)) {
+                    chain.next(example)
+                } else {
+                    chain.stop("Matching exclude filter")
+                }
+            }
+        }
+
+    }
+
+    class StopProcessingException: RuntimeException()
+
+    fun hasMatch(tags: Set<Tag>, root: ExampleGroupContext): Boolean {
+        var match = false
+        val check = object: ContextVisitor {
+            override fun preVisitExampleGroup(context: ExampleGroupContext): Boolean {
+                return true
+            }
+
+            override fun postVisitExampleGroup(context: ExampleGroupContext) {
+            }
+
+            override fun onVisitExample(context: ExampleContext) {
+                match = tags.any {
+                    context.contains(it)
+                }
+
+                if (match) {
+                    throw StopProcessingException()
+                }
+            }
+        }
+
+        try {
+            root.visit(check)
+        } catch (e: StopProcessingException) {
+            // do nothing - this is valid
+        }
+
+        return match
+    }
+}

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/filter/Focused.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/filter/Focused.kt
@@ -1,0 +1,17 @@
+package io.polymorphicpanda.kspec.filter
+
+import io.polymorphicpanda.kspec.config.KSpecConfig
+import io.polymorphicpanda.kspec.context.ExampleGroupContext
+import io.polymorphicpanda.kspec.extension.Extension
+import io.polymorphicpanda.kspec.tag.Tag
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+object Focused: Extension {
+    val tag = Tag("focus")
+
+    override fun configure(config: KSpecConfig, root: ExampleGroupContext) {
+        config.filter.matching(tag)
+    }
+}

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/pending/Pending.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/pending/Pending.kt
@@ -1,7 +1,8 @@
-package io.polymorphicpanda.kspec.extension
+package io.polymorphicpanda.kspec.pending
 
 import io.polymorphicpanda.kspec.config.KSpecConfig
 import io.polymorphicpanda.kspec.context.ExampleGroupContext
+import io.polymorphicpanda.kspec.extension.Extension
 import io.polymorphicpanda.kspec.tag.Tag
 
 /**

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/runner/KSpecRunner.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/runner/KSpecRunner.kt
@@ -5,7 +5,7 @@ import io.polymorphicpanda.kspec.context.Context
 import io.polymorphicpanda.kspec.context.ContextVisitor
 import io.polymorphicpanda.kspec.context.ExampleContext
 import io.polymorphicpanda.kspec.context.ExampleGroupContext
-import io.polymorphicpanda.kspec.extension.CoreExtensions
+import io.polymorphicpanda.kspec.CoreExtensions
 import io.polymorphicpanda.kspec.hook.Chain
 
 /**
@@ -13,11 +13,9 @@ import io.polymorphicpanda.kspec.hook.Chain
  */
 class KSpecRunner(val root: ExampleGroupContext, val config: KSpecConfig = KSpecConfig()) {
     fun run(notifier: RunNotifier) {
-        val clone = config.clone()
+        CoreExtensions.configure(config, root)
 
-        CoreExtensions.configure(clone, root)
-
-        root.visit(Runner(notifier, clone))
+        root.visit(Runner(notifier, config))
     }
 
     internal class Runner(val notifier: RunNotifier, val config: KSpecConfig): ContextVisitor {

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/tag/StandardTags.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/tag/StandardTags.kt
@@ -1,5 +1,7 @@
 package io.polymorphicpanda.kspec.tag
 
-import io.polymorphicpanda.kspec.extension.Pending
+import io.polymorphicpanda.kspec.filter.Focused
+import io.polymorphicpanda.kspec.pending.Pending
 
 fun pending(reason: String) = Pending.tag(reason)
+fun focus() = Focused.tag

--- a/kspec-core/src/test/kotlin/io/polymorphicpanda/kspec/context/ExampleTagTest.kt
+++ b/kspec-core/src/test/kotlin/io/polymorphicpanda/kspec/context/ExampleTagTest.kt
@@ -11,10 +11,12 @@ import org.junit.Test
 class ExampleTagTest {
     @Test
     fun testExampleTagCheck() {
-        val tags = setOf(Tag("focus"))
+        val focus = Tag("focus")
+        val test = Tag("test")
+        val tags = setOf(focus)
         val example = ExampleContext("example", ExampleGroupContext("group", null), null, tags)
 
-        assertThat(example.contains("focus"), equalTo(true))
-        assertThat(example.contains("test"), equalTo(false))
+        assertThat(example.contains(focus), equalTo(true))
+        assertThat(example.contains(test), equalTo(false))
     }
 }

--- a/kspec-core/src/test/kotlin/io/polymorphicpanda/kspec/filter/ExcludeFilterTest.kt
+++ b/kspec-core/src/test/kotlin/io/polymorphicpanda/kspec/filter/ExcludeFilterTest.kt
@@ -1,0 +1,90 @@
+package io.polymorphicpanda.kspec.filter
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import io.polymorphicpanda.kspec.config.KSpecConfig
+import io.polymorphicpanda.kspec.describe
+import io.polymorphicpanda.kspec.it
+import io.polymorphicpanda.kspec.runner.KSpecRunner
+import io.polymorphicpanda.kspec.runner.RunNotifier
+import io.polymorphicpanda.kspec.support.setupSpec
+import io.polymorphicpanda.kspec.tag.Tag
+import org.junit.Test
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+class ExcludeFilterTest {
+    @Test
+    fun testSingle() {
+        val builder = StringBuilder()
+
+        val tag1 = Tag("tag1")
+
+        val root = setupSpec {
+            describe("group") {
+                it("example", tag1) {
+                    builder.appendln("example")
+                }
+
+                it("another example") {
+                    builder.appendln("another example")
+                }
+            }
+        }
+
+        val config = KSpecConfig()
+
+        config.filter.exclude(tag1)
+
+        val notifier = RunNotifier()
+        val runner = KSpecRunner(root, config)
+
+        runner.run(notifier)
+
+        val expected = """
+        another example
+        """.trimIndent()
+
+        assertThat(builder.trimEnd().toString(), equalTo(expected))
+    }
+
+    @Test
+    fun testMultiple() {
+        val builder = StringBuilder()
+
+        val tag1 = Tag("tag1")
+        val tag2 = Tag("tag2")
+
+        val root = setupSpec {
+            describe("group") {
+                it("example", tag1) {
+                    builder.appendln("example")
+                }
+
+                it("another example", tag2) {
+                    builder.appendln("another example")
+                }
+
+                it("yet another example") {
+                    builder.appendln("yet another example")
+                }
+            }
+        }
+
+        val config = KSpecConfig()
+
+        config.filter.exclude(tag1, tag2)
+
+        val notifier = RunNotifier()
+        val runner = KSpecRunner(root, config)
+
+        runner.run(notifier)
+
+        val expected = """
+        yet another example
+        """.trimIndent()
+
+        assertThat(builder.trimEnd().toString(), equalTo(expected))
+    }
+}

--- a/kspec-core/src/test/kotlin/io/polymorphicpanda/kspec/filter/FocusedExampleTest.kt
+++ b/kspec-core/src/test/kotlin/io/polymorphicpanda/kspec/filter/FocusedExampleTest.kt
@@ -1,0 +1,91 @@
+package io.polymorphicpanda.kspec.filter
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import io.polymorphicpanda.kspec.config.KSpecConfig
+import io.polymorphicpanda.kspec.context
+import io.polymorphicpanda.kspec.describe
+import io.polymorphicpanda.kspec.fit
+import io.polymorphicpanda.kspec.it
+import io.polymorphicpanda.kspec.runner.KSpecRunner
+import io.polymorphicpanda.kspec.runner.RunNotifier
+import io.polymorphicpanda.kspec.support.setupSpec
+import org.junit.Test
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+class FocusedExampleTest {
+    @Test
+    fun testMatch() {
+        val builder = StringBuilder()
+
+        val root = setupSpec {
+            describe("group") {
+                fit("focused example") {
+                    builder.appendln("focused example")
+                }
+
+                it("example") {
+                    builder.appendln("example")
+                }
+
+                context("bar") {
+                    fit("another focused example") {
+                        builder.appendln("another focused example")
+                    }
+                }
+            }
+        }
+
+        val config = KSpecConfig()
+        val notifier = RunNotifier()
+        val runner = KSpecRunner(root, config)
+
+        runner.run(notifier)
+
+        val expected = """
+        focused example
+        another focused example
+        """.trimIndent()
+
+        assertThat(builder.trimEnd().toString(), equalTo(expected))
+    }
+
+    @Test
+    fun testNoMatch() {
+        val builder = StringBuilder()
+
+        val root = setupSpec {
+            describe("group") {
+                it("example") {
+                    builder.appendln("example")
+                }
+
+                it("another example") {
+                    builder.appendln("another example")
+                }
+
+                context("bar") {
+                    it("yet another example") {
+                        builder.appendln("yet another example")
+                    }
+                }
+            }
+        }
+
+        val config = KSpecConfig()
+        val notifier = RunNotifier()
+        val runner = KSpecRunner(root, config)
+
+        runner.run(notifier)
+
+        val expected = """
+        example
+        another example
+        yet another example
+        """.trimIndent()
+
+        assertThat(builder.trimEnd().toString(), equalTo(expected))
+    }
+}

--- a/kspec-core/src/test/kotlin/io/polymorphicpanda/kspec/filter/IncludeFilterTest.kt
+++ b/kspec-core/src/test/kotlin/io/polymorphicpanda/kspec/filter/IncludeFilterTest.kt
@@ -1,0 +1,91 @@
+package io.polymorphicpanda.kspec.filter
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import io.polymorphicpanda.kspec.config.KSpecConfig
+import io.polymorphicpanda.kspec.describe
+import io.polymorphicpanda.kspec.it
+import io.polymorphicpanda.kspec.runner.KSpecRunner
+import io.polymorphicpanda.kspec.runner.RunNotifier
+import io.polymorphicpanda.kspec.support.setupSpec
+import io.polymorphicpanda.kspec.tag.Tag
+import org.junit.Test
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+class IncludeFilterTest {
+    @Test
+    fun testSingle() {
+        val builder = StringBuilder()
+
+        val tag1 = Tag("tag1")
+
+        val root = setupSpec {
+            describe("group") {
+                it("example", tag1) {
+                    builder.appendln("example")
+                }
+
+                it("another example") {
+                    builder.appendln("another example")
+                }
+            }
+        }
+
+        val config = KSpecConfig()
+
+        config.filter.include(tag1)
+
+        val notifier = RunNotifier()
+        val runner = KSpecRunner(root, config)
+
+        runner.run(notifier)
+
+        val expected = """
+        example
+        """.trimIndent()
+
+        assertThat(builder.trimEnd().toString(), equalTo(expected))
+    }
+
+    @Test
+    fun testMultiple() {
+        val builder = StringBuilder()
+
+        val tag1 = Tag("tag1")
+        val tag2 = Tag("tag2")
+
+        val root = setupSpec {
+            describe("group") {
+                it("example", tag1) {
+                    builder.appendln("example")
+                }
+
+                it("another example", tag2) {
+                    builder.appendln("another example")
+                }
+
+                it("yet another example") {
+                    builder.appendln("yet another example")
+                }
+            }
+        }
+
+        val config = KSpecConfig()
+
+        config.filter.include(tag1, tag2)
+
+        val notifier = RunNotifier()
+        val runner = KSpecRunner(root, config)
+
+        runner.run(notifier)
+
+        val expected = """
+        example
+        another example
+        """.trimIndent()
+
+        assertThat(builder.trimEnd().toString(), equalTo(expected))
+    }
+}

--- a/kspec-junit-runner/src/main/kotlin/io/polymorphicpanda/kspec/junit/JUnitKSpecRunner.kt
+++ b/kspec-junit-runner/src/main/kotlin/io/polymorphicpanda/kspec/junit/JUnitKSpecRunner.kt
@@ -1,6 +1,7 @@
 package io.polymorphicpanda.kspec.junit
 
 import io.polymorphicpanda.kspec.KSpec
+import io.polymorphicpanda.kspec.config.KSpecConfig
 import io.polymorphicpanda.kspec.context.ExampleContext
 import io.polymorphicpanda.kspec.context.ExampleGroupContext
 import io.polymorphicpanda.kspec.runner.KSpecRunner
@@ -22,7 +23,10 @@ class JUnitKSpecRunner<T: KSpec>(clazz: Class<T>): Runner() {
     }
 
     override fun run(notifier: RunNotifier?) {
-        val runner = KSpecRunner(spec.root)
+        val config = KSpecConfig()
+        spec.configure(config)
+
+        val runner = KSpecRunner(spec.root, config)
         val runNotifier = io.polymorphicpanda.kspec.runner.RunNotifier()
 
         runNotifier.addListener(object: RunListener {

--- a/samples/src/test/kotlin/io/polymorphicpanda/kspec/samples/ExcludeFilterSpec.kt
+++ b/samples/src/test/kotlin/io/polymorphicpanda/kspec/samples/ExcludeFilterSpec.kt
@@ -1,0 +1,35 @@
+package io.polymorphicpanda.kspec.samples
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import io.polymorphicpanda.kspec.KSpec
+import io.polymorphicpanda.kspec.config.KSpecConfig
+import io.polymorphicpanda.kspec.describe
+import io.polymorphicpanda.kspec.it
+import io.polymorphicpanda.kspec.junit.JUnitKSpecRunner
+import io.polymorphicpanda.kspec.tag.Tag
+import org.junit.runner.RunWith
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+@RunWith(JUnitKSpecRunner::class)
+class ExcludeFilterSpec: KSpec() {
+    val tag = Tag("bar")
+
+    override fun configure(config: KSpecConfig) {
+        config.filter.exclude(tag)
+    }
+
+    override fun spec() {
+        describe("a group") {
+            it("some example") {
+                assertThat(true, equalTo(true))
+            }
+
+            it("i should be ignored", tag) {
+                assertThat(true, equalTo(false))
+            }
+        }
+    }
+}

--- a/samples/src/test/kotlin/io/polymorphicpanda/kspec/samples/FocusedExampleSpec.kt
+++ b/samples/src/test/kotlin/io/polymorphicpanda/kspec/samples/FocusedExampleSpec.kt
@@ -1,0 +1,28 @@
+package io.polymorphicpanda.kspec.samples
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import io.polymorphicpanda.kspec.KSpec
+import io.polymorphicpanda.kspec.describe
+import io.polymorphicpanda.kspec.fit
+import io.polymorphicpanda.kspec.it
+import io.polymorphicpanda.kspec.junit.JUnitKSpecRunner
+import org.junit.runner.RunWith
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+@RunWith(JUnitKSpecRunner::class)
+class FocusedExampleSpec: KSpec() {
+    override fun spec() {
+        describe("a group") {
+            fit("example") {
+                assertThat(true, equalTo(true))
+            }
+
+            it("another example") {
+                assertThat(true, equalTo(false))
+            }
+        }
+    }
+}

--- a/samples/src/test/kotlin/io/polymorphicpanda/kspec/samples/IncludeFilterSpec.kt
+++ b/samples/src/test/kotlin/io/polymorphicpanda/kspec/samples/IncludeFilterSpec.kt
@@ -1,0 +1,35 @@
+package io.polymorphicpanda.kspec.samples
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import io.polymorphicpanda.kspec.KSpec
+import io.polymorphicpanda.kspec.config.KSpecConfig
+import io.polymorphicpanda.kspec.describe
+import io.polymorphicpanda.kspec.it
+import io.polymorphicpanda.kspec.junit.JUnitKSpecRunner
+import io.polymorphicpanda.kspec.tag.Tag
+import org.junit.runner.RunWith
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+@RunWith(JUnitKSpecRunner::class)
+class IncludeFilterSpec: KSpec() {
+    val tag = Tag("bar")
+
+    override fun configure(config: KSpecConfig) {
+        config.filter.include(tag)
+    }
+
+    override fun spec() {
+        describe("a group") {
+            it("some example", tag) {
+                assertThat(true, equalTo(true))
+            }
+
+            it("i should be ignored") {
+                assertThat(true, equalTo(false))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #14 

Added filtering via tags when running examples.

```
config.filter.include(tag1, tag2) // run only examples with tag1 or tag2
config.filter.exclude(tag1, tag2) // exclude examples with either tag1 or tag2

config.filter.matching(tag1, ...tagn) // same as filter.include but will only apply if
                                      // any example matches the given tags
```

`focus()` tag is provided and is the default value for `config.filter.matching`. To focus an example
tag it with `focus()` or use `fit(...)` instead of `it(...)`.
