### PR TITLE
Improve ContextVisitor

### DIFF
--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/context/Context.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/context/Context.kt
@@ -43,19 +43,27 @@ class ExampleGroupContext(description: String,
 
 
     companion object {
-        private fun doVisit(visitor: ContextVisitor, context: Context) {
+        private fun doVisit(visitor: ContextVisitor, context: Context): ContextVisitResult {
             when(context) {
                 is ExampleGroupContext -> {
-                    if (visitor.preVisitExampleGroup(context)) {
-                        context.children.forEach { doVisit(visitor, it) }
+                    val result = visitor.preVisitExampleGroup(context)
+
+                    if(result == ContextVisitResult.CONTINUE) {
+                        context.children.forEach {
+                            if (doVisit(visitor, it) == ContextVisitResult.TERMINATE) {
+                                 return ContextVisitResult.TERMINATE
+                            }
+                        }
                     }
 
-                    visitor.postVisitExampleGroup(context)
-                }
-                is ExampleContext -> {
-                    visitor.onVisitExample(context)
+                    if (result != ContextVisitResult.TERMINATE) {
+                        visitor.postVisitExampleGroup(context)
+                    }
+
+                    return result
                 }
             }
+            return visitor.onVisitExample(context as ExampleContext)
         }
     }
 }

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/context/Context.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/context/Context.kt
@@ -57,7 +57,7 @@ class ExampleGroupContext(description: String,
                     }
 
                     if (result != ContextVisitResult.TERMINATE) {
-                        visitor.postVisitExampleGroup(context)
+                        return visitor.postVisitExampleGroup(context)
                     }
 
                     return result

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/context/ContextVisitResult.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/context/ContextVisitResult.kt
@@ -1,0 +1,10 @@
+package io.polymorphicpanda.kspec.context
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+enum class ContextVisitResult {
+    CONTINUE,
+    SKIP,
+    TERMINATE
+}

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/context/ContextVisitResult.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/context/ContextVisitResult.kt
@@ -5,6 +5,6 @@ package io.polymorphicpanda.kspec.context
  */
 enum class ContextVisitResult {
     CONTINUE,
-    SKIP,
+    SKIP_SUBTREE,
     TERMINATE
 }

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/context/ContextVisitor.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/context/ContextVisitor.kt
@@ -1,8 +1,7 @@
 package io.polymorphicpanda.kspec.context
 
 interface ContextVisitor {
-    fun preVisitExampleGroup(context: ExampleGroupContext): Boolean
-    fun postVisitExampleGroup(context: ExampleGroupContext)
-
-    fun onVisitExample(context: ExampleContext)
+    fun preVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult
+    fun onVisitExample(context: ExampleContext): ContextVisitResult
+    fun postVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult
 }

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/runner/KSpecRunner.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/runner/KSpecRunner.kt
@@ -1,11 +1,8 @@
 package io.polymorphicpanda.kspec.runner
 
-import io.polymorphicpanda.kspec.config.KSpecConfig
-import io.polymorphicpanda.kspec.context.Context
-import io.polymorphicpanda.kspec.context.ContextVisitor
-import io.polymorphicpanda.kspec.context.ExampleContext
-import io.polymorphicpanda.kspec.context.ExampleGroupContext
 import io.polymorphicpanda.kspec.CoreExtensions
+import io.polymorphicpanda.kspec.config.KSpecConfig
+import io.polymorphicpanda.kspec.context.*
 import io.polymorphicpanda.kspec.hook.Chain
 
 /**
@@ -37,21 +34,23 @@ class KSpecRunner(val root: ExampleGroupContext, val config: KSpecConfig = KSpec
             }
         }
 
-        override fun preVisitExampleGroup(context: ExampleGroupContext): Boolean {
-            return safeRun(context) { context ->
+        override fun preVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {
+            val success = safeRun(context) { context ->
                 notifier.notifyExampleGroupStarted(context)
                 context.before?.invoke()
             }
+            return if (success) ContextVisitResult.CONTINUE else ContextVisitResult.SKIP
         }
 
-        override fun postVisitExampleGroup(context: ExampleGroupContext) {
+        override fun postVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {
             safeRun(context) { context ->
                 context.after?.invoke()
                 notifier.notifyExampleGroupFinished(context)
             }
+            return ContextVisitResult.CONTINUE
         }
 
-        override fun onVisitExample(context: ExampleContext) {
+        override fun onVisitExample(context: ExampleContext): ContextVisitResult {
             safeRun(context) { context ->
                 config.before.filter { it.handles(context) }
                         .forEach { it.execute(context) }
@@ -68,6 +67,8 @@ class KSpecRunner(val root: ExampleGroupContext, val config: KSpecConfig = KSpec
                 config.after.filter { it.handles(context) }
                         .forEach { it.execute(context) }
             }
+
+            return ContextVisitResult.CONTINUE
         }
 
         private fun invokeBeforeEach(context: ExampleGroupContext) {

--- a/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/runner/KSpecRunner.kt
+++ b/kspec-core/src/main/kotlin/io/polymorphicpanda/kspec/runner/KSpecRunner.kt
@@ -39,7 +39,7 @@ class KSpecRunner(val root: ExampleGroupContext, val config: KSpecConfig = KSpec
                 notifier.notifyExampleGroupStarted(context)
                 context.before?.invoke()
             }
-            return if (success) ContextVisitResult.CONTINUE else ContextVisitResult.SKIP
+            return if (success) ContextVisitResult.CONTINUE else ContextVisitResult.SKIP_SUBTREE
         }
 
         override fun postVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {

--- a/kspec-core/src/test/kotlin/io/polymorphicpanda/kspec/context/ContextVisitorTest.kt
+++ b/kspec-core/src/test/kotlin/io/polymorphicpanda/kspec/context/ContextVisitorTest.kt
@@ -1,0 +1,176 @@
+package io.polymorphicpanda.kspec.context
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import io.polymorphicpanda.kspec.context
+import io.polymorphicpanda.kspec.describe
+import io.polymorphicpanda.kspec.it
+import io.polymorphicpanda.kspec.support.setupSpec
+import org.junit.Test
+
+/**
+ * @author Ranie Jade Ramiso
+ */
+class ContextVisitorTest {
+    val root = setupSpec {
+        describe("test") {
+            context("fooo") {
+                it("bar") {
+
+                }
+
+                context("bar") {
+                    it("shafoo") {
+
+                    }
+                }
+            }
+        }
+
+        it("oh no") {
+
+        }
+    }
+
+    @Test
+    fun testSkipSubTree() {
+        val builder = StringBuilder()
+
+        root.visit(object: ContextVisitor {
+            override fun preVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {
+                builder.appendln("pre - ${context.description}")
+                if (context.description == "context: fooo") {
+                    return ContextVisitResult.SKIP_SUBTREE
+                }
+                return ContextVisitResult.CONTINUE
+            }
+
+            override fun onVisitExample(context: ExampleContext): ContextVisitResult {
+                builder.appendln("on - ${context.description}")
+                return ContextVisitResult.CONTINUE
+            }
+
+            override fun postVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {
+                builder.appendln("post - ${context.description}")
+                return ContextVisitResult.CONTINUE
+            }
+        })
+
+        val expected = """
+            pre - ${root.description}
+            pre - describe: test
+            pre - context: fooo
+            post - context: fooo
+            post - describe: test
+            on - it: oh no
+            post - ${root.description}
+            """.trimIndent()
+
+        assertThat(builder.trimEnd().toString(), equalTo(expected))
+    }
+
+    @Test
+    fun testTerminatePreVisitExampleGroup() {
+        val builder = StringBuilder()
+
+        root.visit(object: ContextVisitor {
+            override fun preVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {
+                builder.appendln("pre - ${context.description}")
+                if (context.description == "context: fooo") {
+                    return ContextVisitResult.TERMINATE
+                }
+                return ContextVisitResult.CONTINUE
+            }
+
+            override fun onVisitExample(context: ExampleContext): ContextVisitResult {
+                builder.appendln("on - ${context.description}")
+                return ContextVisitResult.CONTINUE
+            }
+
+            override fun postVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {
+                builder.appendln("post - ${context.description}")
+                return ContextVisitResult.CONTINUE
+            }
+        })
+
+        val expected = """
+            pre - ${root.description}
+            pre - describe: test
+            pre - context: fooo
+            """.trimIndent()
+
+        assertThat(builder.trimEnd().toString(), equalTo(expected))
+    }
+
+    @Test
+    fun testTerminatePostVisitExampleGroup() {
+        val builder = StringBuilder()
+
+        root.visit(object: ContextVisitor {
+            override fun preVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {
+                builder.appendln("pre - ${context.description}")
+                return ContextVisitResult.CONTINUE
+            }
+
+            override fun onVisitExample(context: ExampleContext): ContextVisitResult {
+                builder.appendln("on - ${context.description}")
+                return ContextVisitResult.CONTINUE
+            }
+
+            override fun postVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {
+                builder.appendln("post - ${context.description}")
+                if (context.description == "context: fooo") {
+                    return ContextVisitResult.TERMINATE
+                }
+                return ContextVisitResult.CONTINUE
+            }
+        })
+
+        val expected = """
+            pre - ${root.description}
+            pre - describe: test
+            pre - context: fooo
+            on - it: bar
+            pre - context: bar
+            on - it: shafoo
+            post - context: bar
+            post - context: fooo
+            """.trimIndent()
+
+        assertThat(builder.trimEnd().toString(), equalTo(expected))
+    }
+
+    @Test
+    fun testTerminateOnVisitExample() {
+        val builder = StringBuilder()
+
+        root.visit(object: ContextVisitor {
+            override fun preVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {
+                builder.appendln("pre - ${context.description}")
+                return ContextVisitResult.CONTINUE
+            }
+
+            override fun onVisitExample(context: ExampleContext): ContextVisitResult {
+                builder.appendln("on - ${context.description}")
+                if (context.description == "it: bar") {
+                    return ContextVisitResult.TERMINATE
+                }
+                return ContextVisitResult.CONTINUE
+            }
+
+            override fun postVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {
+                builder.appendln("post - ${context.description}")
+                return ContextVisitResult.CONTINUE
+            }
+        })
+
+        val expected = """
+            pre - ${root.description}
+            pre - describe: test
+            pre - context: fooo
+            on - it: bar
+            """.trimIndent()
+
+        assertThat(builder.trimEnd().toString(), equalTo(expected))
+    }
+}

--- a/kspec-junit-runner/src/main/kotlin/io/polymorphicpanda/kspec/junit/JUnitTestDescriber.kt
+++ b/kspec-junit-runner/src/main/kotlin/io/polymorphicpanda/kspec/junit/JUnitTestDescriber.kt
@@ -1,9 +1,6 @@
 package io.polymorphicpanda.kspec.junit
 
-import io.polymorphicpanda.kspec.context.Context
-import io.polymorphicpanda.kspec.context.ContextVisitor
-import io.polymorphicpanda.kspec.context.ExampleContext
-import io.polymorphicpanda.kspec.context.ExampleGroupContext
+import io.polymorphicpanda.kspec.context.*
 import org.junit.runner.Description
 import java.io.Serializable
 import java.util.*
@@ -40,21 +37,23 @@ class JUnitTestDescriber: ContextVisitor {
 
     }
 
-    override fun preVisitExampleGroup(context: ExampleGroupContext): Boolean {
+    override fun preVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {
         contextDescriptions.put(context, Description.createSuiteDescription(context.description, JUnitUniqueId.next()))
-        return true
+        return ContextVisitResult.CONTINUE
     }
 
-    override fun postVisitExampleGroup(context: ExampleGroupContext) {
+    override fun postVisitExampleGroup(context: ExampleGroupContext): ContextVisitResult {
         val current = contextDescriptions[context]
 
         if (context.parent != null) {
             val parent = contextDescriptions[context.parent!!]
             parent!!.addChild(current)
         }
+
+        return ContextVisitResult.CONTINUE
     }
 
-    override fun onVisitExample(context: ExampleContext) {
+    override fun onVisitExample(context: ExampleContext): ContextVisitResult {
         val desc = Description.createTestDescription(
                 className(context.parent), context.description, JUnitUniqueId.next()
         )
@@ -65,6 +64,8 @@ class JUnitTestDescriber: ContextVisitor {
 
         val parent = contextDescriptions[context.parent]
         parent!!.addChild(desc)
+
+        return ContextVisitResult.CONTINUE
     }
 
 }


### PR DESCRIPTION
Introduce ContextVisitResult that control the tree traversal. There are
still some checks missing like when `preVisitExampleGroup` returns `SKIP` and
handling for the return value of `postVisitExampleGroup`.
